### PR TITLE
Decode upper case as well; add START, END parameters.

### DIFF
--- a/tests.lisp
+++ b/tests.lisp
@@ -42,4 +42,17 @@
   (assert-equalp #(1 2 3)
 		(base32-to-bytes (string-upcase (bytes-to-base32 #(1 2 3))))))
 
+(define-test offset-decoding
+  (assert-equalp
+   #(1 2 3 253 254 255)
+   (let ((encoded (bytes-to-base32 #(1 2 3 253 254 255))))
+     (base32-to-bytes
+      (concatenate 'string "foo" encoded "bar")
+      :start 3
+      :end (+ (length encoded) 3)))))
+
+(define-test offset-encoding
+  (assert-equalp #(2 3 253 254)
+		(base32-to-bytes (bytes-to-base32 #(1 2 3 253 254 255) :start 1 :end 5))))
+
 (run-tests :all :cl-base32-tests)


### PR DESCRIPTION
The attached commit changes the decoding so that A-Z are decoded as well. Also the decoding function doesn't do linear search anymore, so it's a bit faster. A test case is included as well.
